### PR TITLE
Fix Dilation Autobuyers & Hopefully fix mends/mending points becoming non Decimal

### DIFF
--- a/src/components/tabs/time-dilation/DilationUpgradeButton.vue
+++ b/src/components/tabs/time-dilation/DilationUpgradeButton.vue
@@ -73,7 +73,10 @@ export default {
   },
   watch: {
     isAutobuyerOn(newValue) {
-      Autobuyer.dilationUpgrade(this.upgrade.id).isActive = newValue;
+      if (this.upgrade.id < 4) {
+        Autobuyer.dilationUpgrade(this.upgrade.id).isActive = newValue;
+      }
+      Autobuyer.dilationUpgrade(this.upgrade.id - 7).isActive = newValue;
     }
   },
   methods: {
@@ -86,10 +89,16 @@ export default {
       if (this.isRebuyable) {
         this.isAffordable = upgrade.isAffordable;
         this.isCapped = upgrade.isCapped;
-        const autobuyer = Autobuyer.dilationUpgrade(upgrade.id);
+        let autobuyer = Autobuyer.dilationUpgrade(upgrade.id);
+        if (upgrade.id > 3) {
+          autobuyer = Autobuyer.dilationUpgrade(upgrade.id - 7)
+        }
         this.boughtAmount = upgrade.boughtAmount;
         this.rebuyableBoost = PelleRifts.paradox.milestones[2].canBeApplied;
-        if (!autobuyer) return;
+        if (!autobuyer) {
+          console.log("return");
+          return;
+        }
         this.isAutoUnlocked = autobuyer.isUnlocked;
         this.isAutobuyerOn = autobuyer.isActive;
         return;

--- a/src/core/autobuyers/dilation-upgrade-autobuyer.js
+++ b/src/core/autobuyers/dilation-upgrade-autobuyer.js
@@ -1,4 +1,4 @@
-import { PlayerProgress } from "../player-progress";
+
 import { IntervaledAutobuyerState } from "./autobuyer";
 import { MendingMilestone } from "../mending";
 
@@ -20,10 +20,9 @@ export class DilationUpgradeAutobuyerState extends IntervaledAutobuyerState {
   get isUnlocked() {
     const upgradeName = this._upgradeName;
     if (upgradeName == "dtGainPelle" || upgradeName == "galaxyMultiplier" || upgradeName == "tickspeedPower"){
-      if (Pelle.isDoomed) return false;
-      return true;
+      return MendingMilestone.two.isReached
     }
-    return (Perk.autobuyerDilation.isEffectActive && !Pelle.isDoomed) || PlayerProgress.mendingUnlocked();
+    return (Perk.autobuyerDilation.isEffectActive && !Pelle.isDoomed) || (MendingMilestone.one.isReached);
   }
 
   get resetTickOn() {
@@ -41,10 +40,7 @@ export class DilationUpgradeAutobuyerState extends IntervaledAutobuyerState {
   }
 
   static get entryCount() { 
-    if (MendingMilestone.two.isReached){
-      return 6;
-    }
-    return 3; 
+    return 6
   }
   static get autobuyerGroupName() { return "Dilation Upgrade"; }
   static get isActive() { return player.auto.dilationUpgrades.isActive; }

--- a/src/core/currency.js
+++ b/src/core/currency.js
@@ -487,7 +487,7 @@ Currency.mendingPoints = new class extends DecimalCurrency {
     return player.mendingPoints; 
   }
   set value(value) {
-    player.mendingPoints = value;
+    player.mendingPoints = value.toDecimal();
   }
 
   get startingValue() {
@@ -504,7 +504,7 @@ Currency.mends = new class extends DecimalCurrency {
     return player.mends; 
   }
   set value(value) {
-    player.mends = value;
+    player.mends = value.toDecimal();
   }
 
   get startingValue() {

--- a/src/core/imaginary-upgrades.js
+++ b/src/core/imaginary-upgrades.js
@@ -65,11 +65,11 @@ class ImaginaryUpgradeState extends BitPurchasableMechanicState {
   }
 
   get isAvailableForPurchase() {
-    return (player.reality.imaginaryUpgReqs & (1 << this.id)) !== 0 || (MendingMilestone.four.isReached && this.id !=25 && this.id != 15);
+    return (player.reality.imaginaryUpgReqs & (1 << this.id)) !== 0 || (MendingMilestone.four.isReached && ![25, 15].includes(this.id));
   }
 
   get isPossible() {
-    if(MendingMilestone.four.isReached && this.id != 25 && this.id != 15){
+    if(MendingMilestone.four.isReached && ![25, 15].includes(this.id)){
       return true;
     }
     return this.config.hasFailed ? !this.config.hasFailed() : true;

--- a/src/core/storage/migrations.js
+++ b/src/core/storage/migrations.js
@@ -461,6 +461,14 @@ export const migrations = {
       if (MendingMilestone.three.isReached){
         player.celestials.ra.unlockBits += 2097152;
       }
+    },
+    36: player => {
+      player.auto.dilationUpgrades.all = Array.range(0, 3).concat(Array.range(11, 14)).map(() => ({
+        isActive: false,
+        lastTick: 0,
+      }))
+      player.mends = new Decimal(player.mends)
+      player.mendingPoints = new Decimal(player.mendingPoints)
     }
   },
 


### PR DESCRIPTION
Its a bunch of small changes. migrations.js is just to fix older saves if they are missing the Pelle dilation rebuyable auto, as well as redecimalizing mends & mendingPoints.