### PR TITLE
fixes a bug

### DIFF
--- a/src/game.js
+++ b/src/game.js
@@ -694,7 +694,7 @@ function updatePrestigeRates() {
 }
 
 function passivePrestigeGen() {
-  let eternitiedGain = 0;
+  let eternitiedGain = DC.D0;
   if (RealityUpgrade(14).isBought) {
     eternitiedGain = DC.D1.timesEffectsOf(
       Achievement(113),


### PR DESCRIPTION
If you complete Effarig's Eternity before buying Reality Upgrade 12 (the one that gives you passive eternity gain), the game will throw an error. 